### PR TITLE
fix(coinFlip): correct grammatical error

### DIFF
--- a/commands/coinFlip.js
+++ b/commands/coinFlip.js
@@ -13,7 +13,7 @@ module.exports = {
         : 'http://assets.stickpng.com/thumbs/5a521f522f93c7a8d5137fc7.png';
     */
         const img = coinNum === 0 ? "attachment://heads.png" : "attachment://tails.png";
-        const embed = new MessageEmbed().setTitle(`its ${coin}!`).setImage(img);
+        const embed = new MessageEmbed().setTitle(`it's ${coin}!`).setImage(img);
         if (coinNum == 0) {
             return await interaction.reply({
                 embeds: [embed],


### PR DESCRIPTION
fix a grammatical error with using `its` instead of `it's`

![example](https://user-images.githubusercontent.com/25019123/199903535-cb1b148d-28f1-4613-99df-bb5931aebefe.png)
