### PR TITLE
fix(24parser): catch mathjs compilation failure

### DIFF
--- a/commands/24parser.js
+++ b/commands/24parser.js
@@ -1,7 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
-const { isNaN } = require("mathjs");
-const { Util } = require("discord.js");
 const math = require("mathjs");
+const { Util } = require("discord.js");
 
 const illegalPhraseRegexes = [/`/g, /@/g];
 
@@ -9,51 +8,27 @@ const isIllegalCharactersPresent = (expression) => {
     return illegalPhraseRegexes.some((regex) => regex.test(expression));
 };
 
-const evaluate = (equationString, target) => {
-    if (isIllegalCharactersPresent(equationString)) {
-        return {
-            success: false,
-            message: "Could not compile. Illegal input detected.",
-            ephemeral: true,
-        };
-    }
+const tryCompileAndEvaluate = (eqnString) => {
+    try {
+        const equationObj = math.compile(eqnString);
+        if (!equationObj) {
+            throw Error;
+        }
 
-    const equationObj = math.compile(equationString);
-    if (!equationObj) {
+        const equationOutcome = equationObj.evaluate();
+
+        return {
+            success: true,
+            equationOutcome,
+        };
+
+    } catch (e) {
         return {
             success: false,
             message: "Could not compile. The equation is invalid.",
             ephemeral: true,
         };
     }
-
-    const equationOutcome = equationObj.evaluate();
-    const outcomeAsNumber = Number(equationOutcome);
-    if (isNaN(outcomeAsNumber)) {
-        return {
-            success: false,
-            message: "Could not compile. The equation does not evaluate to a number.",
-            ephemeral: true,
-        };
-    }
-
-    return outcomeAsNumber == target
-        ? {
-              success: true,
-              message: `Correct! \`${equationString}\` = ${target}, which is equal to the target of ${target}.`,
-              ephemeral: false,
-          }
-        : {
-              success: false,
-              message: `Incorrect. \`${equationString}\` = ${outcomeAsNumber}, which is not equal to the target of ${target}.`,
-              ephemeral: false,
-          };
-};
-
-const illegalPhraseRegexes = [ /`/g, /@/g ];
-
-const isIllegalCharactersPresent = (expression) => {
-    return illegalPhraseRegexes.some((regex) => regex.test(expression));
 };
 
 const evaluate = (equationString, target) => {
@@ -65,18 +40,18 @@ const evaluate = (equationString, target) => {
         };
     }
 
-    const equationObj = math.compile(equationString);
-    if (!equationObj) {
+    const evaluationOutcome = tryCompileAndEvaluate(equationString);
+    if (!evaluationOutcome.success) {
         return {
             success: false,
-            message: "Could not compile. The equation is invalid.",
+            message: evaluationOutcome.message,
             ephemeral: true,
         };
     }
+    const { equationOutcome } = evaluationOutcome;
 
-    const equationOutcome = equationObj.evaluate();
     const outcomeAsNumber = Number(equationOutcome);
-    if (isNaN(outcomeAsNumber)) {
+    if (math.isNaN(outcomeAsNumber)) {
         return {
             success: false,
             message: "Could not compile. The equation does not evaluate to a number.",

--- a/commands/24parser.js
+++ b/commands/24parser.js
@@ -59,11 +59,13 @@ const evaluate = (equationString, target) => {
         };
     }
 
-    return (outcomeAsNumber == target) ? {
+    return outcomeAsNumber == target
+    ? {
         success: true,
         message: `Correct! \`${equationString}\` = ${target}, which is equal to the target.`,
         ephemeral: false,
-    } : {
+      }
+    : {
         success: false,
         message: `Incorrect. \`${equationString}\` = ${outcomeAsNumber}, which is not equal to the target of ${target}.`,
         ephemeral: false,

--- a/commands/24parser.js
+++ b/commands/24parser.js
@@ -50,6 +50,52 @@ const evaluate = (equationString, target) => {
           };
 };
 
+const illegalPhraseRegexes = [ /`/g, /@/g ];
+
+const isIllegalCharactersPresent = (expression) => {
+    return illegalPhraseRegexes.some((regex) => regex.test(expression));
+};
+
+const evaluate = (equationString, target) => {
+    if (isIllegalCharactersPresent(equationString)) {
+        return {
+            success: false,
+            message: "Could not compile. Illegal input detected.",
+            ephemeral: true,
+        };
+    }
+
+    const equationObj = math.compile(equationString);
+    if (!equationObj) {
+        return {
+            success: false,
+            message: "Could not compile. The equation is invalid.",
+            ephemeral: true,
+        };
+    }
+
+    const equationOutcome = equationObj.evaluate();
+    const outcomeAsNumber = Number(equationOutcome);
+    if (isNaN(outcomeAsNumber)) {
+        return {
+            success: false,
+            message: "Could not compile. The equation does not evaluate to a number.",
+            ephemeral: true,
+        };
+    }
+
+    return (outcomeAsNumber == target) ? {
+        success: true,
+        message: `Correct! \`${equationString}\` = ${target}, which is equal to the target`,
+        ephemeral: false,
+    } : {
+        success: false,
+        message: `Incorrect. \`${equationString}\` = ${outcomeAsNumber}, which is not equal to the target`,
+        ephemeral: false,
+    };
+
+};
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName("24parse")
@@ -75,3 +121,4 @@ module.exports = {
         });
     },
 };
+

--- a/commands/24parser.js
+++ b/commands/24parser.js
@@ -61,11 +61,11 @@ const evaluate = (equationString, target) => {
 
     return (outcomeAsNumber == target) ? {
         success: true,
-        message: `Correct! \`${equationString}\` = ${target}, which is equal to the target`,
+        message: `Correct! \`${equationString}\` = ${target}, which is equal to the target.`,
         ephemeral: false,
     } : {
         success: false,
-        message: `Incorrect. \`${equationString}\` = ${outcomeAsNumber}, which is not equal to the target`,
+        message: `Incorrect. \`${equationString}\` = ${outcomeAsNumber}, which is not equal to the target of ${target}.`,
         ephemeral: false,
     };
 


### PR DESCRIPTION
- currently there is a check to make sure that the mathjs compiled object is not undefined in case of a failure to compile.
- this does not account for the case where the input causes an exception, leading to the following, unhelpful response (see attached)
<img width="388" alt="image" src="https://user-images.githubusercontent.com/93496985/211704966-b549824d-1f03-438e-84d1-97e7d1f87798.png">

- added a simple try-catch to inform users of what went wrong
