### PR TITLE
Dev/upgrade handbook url

### DIFF
--- a/commands/handbook.js
+++ b/commands/handbook.js
@@ -74,7 +74,7 @@ module.exports = {
                         value:
                             raw_requirements.replace(
                                 /[A-Z]{4}[0-9]{4}/g,
-                                `[$&](${handbookURL}$&)`,
+                                `[$&](${handbookURL}/$&)`,
                             ) || "None",
                         inline: true,
                     },
@@ -86,8 +86,8 @@ module.exports = {
                     {
                         name: "Equivalent Courses",
                         value:
-                            Object.keys(equivalents)
-                                .map((course) => `[${course}](${course})`)
+                            Object.keys(exclusions)
+                                .map((course) => `[${course}](${handbookURL}/${course})`)
                                 .join(", ") || "None",
                         inline: true,
                     },
@@ -95,7 +95,7 @@ module.exports = {
                         name: "Exclusion Courses",
                         value:
                             Object.keys(exclusions)
-                                .map((course) => `[${course}](${handbookURL}${course})`)
+                                .map((course) => `[${course}](${handbookURL}/${course})`)
                                 .join(", ") || "None",
                         inline: true,
                     },

--- a/commands/handbook.js
+++ b/commands/handbook.js
@@ -48,7 +48,7 @@ module.exports = {
                 // study_level,
                 // school,
                 // campus,
-                equivalents,
+                // equivalents,
                 raw_requirements,
                 exclusions,
                 // handbook_note,

--- a/config/handbook.json
+++ b/config/handbook.json
@@ -1,4 +1,4 @@
 {
     "apiURL": "https://circlesapi.csesoc.app",
-    "handbookURL": "https://www.handbook.unsw.edu.au/undergraduate/courses/2022/"
+    "handbookURL": "https://www.handbook.unsw.edu.au/undergraduate/courses/2024"
 }


### PR DESCRIPTION
Upgraded handbook url in config.json to use 2024. Also fixed incorrect url links in the handbook.js command.

![image](https://github.com/csesoc/discord-bot/assets/44077482/17d15156-5251-4198-a40d-648278bbbe70)