### PR TITLE
[DISC-109] Adding bot-status for events and member count

### DIFF
--- a/events/log_ready.js
+++ b/events/log_ready.js
@@ -1,9 +1,12 @@
 const { DBlog } = require("../lib/database/dblog");
 
 let currentStatusIndex = 0;
-let currentEventIndex = 0;
+const CSESOC_SERVER_ID = "693779865916276746";
 const statusSeconds = 30;
-const events = ["EVENT"];
+
+// In case of events working
+// let currentEventIndex = 0;
+// const events = ["EVENT"];
 
 module.exports = {
     name: "ready",
@@ -32,7 +35,7 @@ module.exports = {
         // Status change functions
         const statusFunctions = [
             () => memberCountStatus(client),
-            () => specialEventStatus(client, events[currentEventIndex]),
+            // () => specialEventStatus(client, events[currentEventIndex]),
         ];
 
         setInterval(() => {
@@ -43,14 +46,15 @@ module.exports = {
 };
 
 function memberCountStatus(client) {
-    let memberCount = 0;
-    client.guilds.cache.forEach((guild) => {
-        memberCount += guild.memberCount;
-    });
-    client.user.setActivity(`${memberCount} total members!`, { type: "LISTENING" });
+    const server = client.guilds.cache.get(CSESOC_SERVER_ID);
+    if (!server) {
+        return;
+    }
+
+    client.user.setActivity(`${server.memberCount} members!`, { type: "LISTENING" });
 }
 
-function specialEventStatus(client, event) {
-    client.user.setActivity(event, { type: "COMPETING" });
-    currentEventIndex = (currentEventIndex + 1) % events.length;
-}
+// function specialEventStatus(client, event) {
+//     client.user.setActivity(event, { type: "COMPETING" });
+//     currentEventIndex = (currentEventIndex + 1) % events.length;
+// }

--- a/events/log_ready.js
+++ b/events/log_ready.js
@@ -1,5 +1,10 @@
 const { DBlog } = require("../lib/database/dblog");
 
+let currentStatusIndex = 0;
+let currentEventIndex = 0;
+const statusSeconds = 30;
+const events = ["EVENT"];
+
 module.exports = {
     name: "ready",
     once: true,
@@ -23,5 +28,29 @@ module.exports = {
                 }
             }
         })();
+
+        // Status change functions
+        const statusFunctions = [
+            () => memberCountStatus(client),
+            () => specialEventStatus(client, events[currentEventIndex])
+        ];
+        
+        setInterval(() => {
+            statusFunctions[currentStatusIndex]();
+            currentStatusIndex = (currentStatusIndex + 1) % statusFunctions.length;
+        }, 1000*statusSeconds);
     },
 };
+
+function memberCountStatus(client) {
+    let memberCount = 0;
+    client.guilds.cache.forEach(guild => {
+        memberCount += guild.memberCount;
+    });
+    client.user.setActivity(`${memberCount} total members!`, { type: "LISTENING"});
+}
+
+function specialEventStatus(client, event) {
+    client.user.setActivity(event, { type: "COMPETING"})
+    currentEventIndex = (currentEventIndex + 1) % events.length;
+}

--- a/events/log_ready.js
+++ b/events/log_ready.js
@@ -32,25 +32,25 @@ module.exports = {
         // Status change functions
         const statusFunctions = [
             () => memberCountStatus(client),
-            () => specialEventStatus(client, events[currentEventIndex])
+            () => specialEventStatus(client, events[currentEventIndex]),
         ];
-        
+
         setInterval(() => {
             statusFunctions[currentStatusIndex]();
             currentStatusIndex = (currentStatusIndex + 1) % statusFunctions.length;
-        }, 1000*statusSeconds);
+        }, 1000 * statusSeconds);
     },
 };
 
 function memberCountStatus(client) {
     let memberCount = 0;
-    client.guilds.cache.forEach(guild => {
+    client.guilds.cache.forEach((guild) => {
         memberCount += guild.memberCount;
     });
-    client.user.setActivity(`${memberCount} total members!`, { type: "LISTENING"});
+    client.user.setActivity(`${memberCount} total members!`, { type: "LISTENING" });
 }
 
 function specialEventStatus(client, event) {
-    client.user.setActivity(event, { type: "COMPETING"})
+    client.user.setActivity(event, { type: "COMPETING" });
     currentEventIndex = (currentEventIndex + 1) % events.length;
 }


### PR DESCRIPTION
### Why the changes are required?
### Changes
- added a `setInterval()` timer which switches between statusChange functions to change status after `statusSeconds` seconds (currently 30 seconds)
- Status for member count: "Listening to `${memberCount}` total members!"
- Status for event: "Competing in `events[index]`" 
- Added events array which are currently just strings
- Added member count function which sums up members of the server 

### Comments
Assumptions:
- Currently assumes the bot solely exists on a server for member count (might count extra members if its on other servers)

Other comments:
- Currently switches between statuses every 30 seconds (can change)
- Currently has placeholder text for events, not sure what to add yet (maybe could use that fb scraper for events if it is functional)
- Can add different status verbs Competing, Listening, etc for events 