### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
-                  password: ${{ secrets.GH_TOKEN }}
+                  password: ${{ github.token }}
             - name: Build and push Docker image
               uses: docker/build-push-action@v4
               with:
@@ -58,37 +58,13 @@ jobs:
         environment:
             name: production (projects-bot)
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+            - name: Dispatch deployment
+              uses: devsoc-unsw/deployment-dispatch-action@main
               with:
-                  repository: csesoc/deployment
-                  token: ${{ secrets.GH_TOKEN }}
-            - name: Install yq - portable yaml processor
-              uses: mikefarah/yq@v4.44.2
-            - name: Determine file to update
-              id: get_manifest
-              env:
-                  BRANCH_NAME: ${{ github.ref }}
-              run: |
-                  if [ "$BRANCH_NAME" = "refs/heads/projects-bot" ]; then
-                      echo "MANIFEST=projects/bot/ptb/deploy.yml" >> $GITHUB_OUTPUT
-                      echo "DEPLOYMENT=ptb" >> $GITHUB_OUTPUT
-                  elif [ "$BRANCH_NAME" = "refs/heads/develop" ]; then
-                      echo "MANIFEST=projects/bot/qa/deploy.yml" >> $GITHUB_OUTPUT
-                      echo "DEPLOYMENT=qa" >> $GITHUB_OUTPUT
-                  else
-                      exit 1
-                  fi
-            - name: Update deployment
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-              run: |
-                  git config user.name "CSESoc CD"
-                  git config user.email "technical@csesoc.org.au"
-                  git checkout -b update/projects-bot/${{ github.sha }}
-                  yq -i '.spec.template.spec.containers[0].image = "ghcr.io/csesoc/projects-discord-bot:${{ github.sha }}"' ${{ steps.get_manifest.outputs.MANIFEST }}
-                  git add .
-                  git commit -m "feat(projects-bot/${{ steps.get_manifest.outputs.DEPLOYMENT }}): update images"
-                  git push -u origin update/projects-bot/${{ github.sha }}
-                  gh pr create --title "feat(projects-bot/${{ steps.get_manifest.outputs.DEPLOYMENT }}): update images" --body "Updates the images for the projects-bot deployment to commit csesoc/discord-bot@${{ github.sha }}." > URL
-                  gh pr merge $(cat URL) --squash -d
+                  deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
+                  deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+                  owner: csesoc
+                  repository: deployment
+                  ref: develop
+                  updates: |
+                      ghcr.io/csesoc/projects-discord-bot=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Build projects-bot
 on:
     push:
 
+env:
+    IMAGE_NAME: ${{ github.ref_name == 'projects-bot' && 'projects-discord-bot' || 'projects-discord-bot-qa' }}
+
 jobs:
     format-lint-check:
         name: "Format & lint check"
@@ -46,8 +49,8 @@ jobs:
                   platforms: linux/amd64
                   file: Dockerfile
                   tags: |
-                      ghcr.io/csesoc/projects-discord-bot:${{ github.sha }}
-                      ghcr.io/csesoc/projects-discord-bot:latest
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}:latest
                   labels: ${{ steps.meta.outputs.labels }}
     deploy:
         name: Deploy (CD)
@@ -67,4 +70,4 @@ jobs:
                   repository: deployment
                   ref: develop
                   updates: |
-                      ghcr.io/csesoc/projects-discord-bot=${{ github.sha }}
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `csesoc/deployment` from this repo's workflow, and split qa from ptb by publishing to distinct image names.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- switch GHCR publish authentication to `github.token`
- publish `projects-bot` to `ghcr.io/csesoc/projects-discord-bot`
- publish `develop` to `ghcr.io/csesoc/projects-discord-bot-qa`
- dispatch the branch-specific image name instead of a shared image name
- use `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`

## Context
This supersedes the earlier dispatch-only PR for `develop` because `csesoc/deployment` matches manifests by image name. Without distinct image names, dispatch updates would hit both qa and ptb.

## Dependencies
- `csesoc/deployment` PR: https://github.com/csesoc/deployment/pull/3873

## Verification
- `rg -n "\\bGH_TOKEN\\b|IMAGE_NAME|projects-discord-bot-qa" . -S -g '!node_modules'`
- `actionlint -color .github/workflows/docker.yml` still reports the same pre-existing baseline issues for old Docker action refs and the missing `steps.meta` definition
