### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,9 @@ name: Build projects-bot
 
 on:
     push:
+        branches:
+            - develop
+            - projects-bot
 
 env:
     IMAGE_NAME: ${{ github.ref_name == 'projects-bot' && 'projects-discord-bot' || 'projects-discord-bot-qa' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Build projects-bot
 on:
     push:
 
+env:
+    IMAGE_NAME: ${{ github.ref_name == 'projects-bot' && 'projects-discord-bot' || 'projects-discord-bot-qa' }}
+
 jobs:
     format-lint-check:
         name: "Format & lint check"
@@ -46,8 +49,8 @@ jobs:
                   platforms: linux/amd64
                   file: Dockerfile
                   tags: |
-                      ghcr.io/csesoc/projects-discord-bot:${{ github.sha }}
-                      ghcr.io/csesoc/projects-discord-bot:latest
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}:latest
                   labels: ${{ steps.meta.outputs.labels }}
     deploy:
         name: Deploy (CD)
@@ -67,4 +70,4 @@ jobs:
                   repository: deployment
                   ref: develop
                   updates: |
-                      ghcr.io/csesoc/projects-discord-bot=${{ github.sha }}
+                      ghcr.io/csesoc/${{ env.IMAGE_NAME }}=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `csesoc/deployment` from this repo's workflow, and split qa from ptb by publishing to distinct image names.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- switch GHCR publish authentication to `github.token`
- publish `projects-bot` to `ghcr.io/csesoc/projects-discord-bot`
- publish `develop` to `ghcr.io/csesoc/projects-discord-bot-qa`
- dispatch the branch-specific image name instead of a shared image name
- use `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`

## Dependencies
- `csesoc/deployment` PR: https://github.com/csesoc/deployment/pull/3873

## Verification
- `rg -n "\\bGH_TOKEN\\b|IMAGE_NAME|projects-discord-bot-qa" . -S -g '!node_modules'`
- `actionlint -color .github/workflows/docker.yml` still reports the same pre-existing baseline issues for old Docker action refs and the missing `steps.meta` definition
